### PR TITLE
Specify package version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "version": "1.2.0",
   "scripts": {
     "build": "echo building... && typings bundle -o out",
     "lint": "echo linting... && tslint \"**/*.ts\" -e \"out/**\" -e \"node_modules/**\" -e \"typings/**\""


### PR DESCRIPTION
The package currently does not have a version attribute. This breaks yarn lockfile support, I get the following error when trying to install typed-save-svg-as-png:

    error Package "@types/save-svg-as-png@" doesn't have a "version".

Just adding a version solved the problem for me.